### PR TITLE
Fix for 5 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "glob": "^3.2.11",
     "handlebars": "^2.0.0-alpha.4",
     "marked": "^0.3.2",
-    "request": "~2.30.0",
+    "request": "~2.74.0",
     "workshopper-jlord": "tjheffner/workshopper",
     "cheerio": "~0.17.0"
   }


### PR DESCRIPTION
pattern-lab-workshop currently has a 11 vulnerable dependency paths, introducing 10 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
- [Denial of Service (Event Loop Blocking)](https://snyk.io/vuln/npm:qs:20140806-1) vulnerability in the `qs` dependency.
- [Denial of Service (Memory Exhaustion)](https://snyk.io/vuln/npm:qs:20140806) vulnerability in the `qs` dependency.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/phase2/pattern-lab-workshop) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team
